### PR TITLE
Feat: 1.5.0 모달 컴포넌트에 기본 버튼 선택 옵션 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "momodal-library",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Accessible modal component for React.JS",
   "main": "./dist/momodal-library.cjs.js",
   "module": "./dist/momodal-library.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "momodal-library",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Accessible modal component for React.JS",
   "main": "./dist/momodal-library.cjs.js",
   "module": "./dist/momodal-library.es.js",

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -9,6 +9,7 @@ interface ModalProps {
   width?: number;
   padding?: number;
   borderRadius?: number;
+  showCloseButton?: boolean;
 }
 
 const Modal = ({
@@ -18,6 +19,7 @@ const Modal = ({
   width = 400,
   padding = 20,
   borderRadius = 8,
+  showCloseButton = true,
 }: ModalProps) => {
   if (!isOpen) return null;
 
@@ -33,9 +35,11 @@ const Modal = ({
         onClick={(e) => e.stopPropagation()}
       >
         <div style={styles.content}>{children}</div>
-        <button onClick={onClose} style={styles.closeButton}>
-          닫기
-        </button>
+        {showCloseButton && (
+          <button onClick={onClose} style={styles.closeButton}>
+            닫기
+          </button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## 🔎 작업 내용
- Modal 컴포넌트 내부에서 사용되는 버튼 요소를 선택적으로 렌더링 할 수 있게 구현
- `showCloseButton` 을 기본 `true`로 제공하고, `Button` 컴포넌트 사용시 해당 옵션을 `false`로 설정

```js
<Modal
   ...
  showCloseButton={true} // 기본 닫기 버튼 보이기 여부 (기본값: true)
></Modal>
```

## 🚀 기대 효과
- 사용자가 모달 내부에 사용할 버튼을 더 유연하게 커스터마이징할 수 있습니다.
- 제공되는 `Button`  컴포넌트를 활용할 수 있습니다